### PR TITLE
fix service principal id

### DIFF
--- a/workload/terraform/modules/avd/personal/personalpool.tf
+++ b/workload/terraform/modules/avd/personal/personalpool.tf
@@ -50,7 +50,7 @@ resource "azurerm_role_assignment" "power" {
   name                             = random_uuid.example.result
   scope                            = azurerm_resource_group.rg.id
   role_definition_id               = data.azurerm_role_definition.power_role.role_definition_id
-  principal_id                     = data.azuread_service_principal.spn.application_id
+  principal_id                     = data.azuread_service_principal.spn.object_id
   skip_service_principal_aad_check = true
   depends_on                       = [data.azurerm_role_definition.power_role]
 }


### PR DESCRIPTION
## Summary
- use service principal object id for role assignment in personal pool module

## Testing
- `terraform -chdir=workload/terraform/modules/avd/personal init -backend=false`
- `terraform -chdir=workload/terraform/modules/avd/personal validate` *(fails: Reference to undeclared resource)*

------
https://chatgpt.com/codex/tasks/task_b_68ad7a73acc48332a844b75630057d79