### PR TITLE
Use storage account ID in FSShare Terraform resource

### DIFF
--- a/workload/terraform/greenfield/AADDSscenario/afstorage.tf
+++ b/workload/terraform/greenfield/AADDSscenario/afstorage.tf
@@ -28,8 +28,8 @@ resource "azurerm_storage_share" "FSShare" {
   enabled_protocol = "SMB"
 
 
-  storage_account_name = azurerm_storage_account.storage.name
-  depends_on           = [azurerm_storage_account.storage]
+  storage_account_id = azurerm_storage_account.storage.id
+  depends_on         = [azurerm_storage_account.storage]
 }
 
 


### PR DESCRIPTION
## Summary
- use storage account id for FSShare

## Testing
- `terraform fmt afstorage.tf`
- `terraform validate` *(fails: Missing required argument "monitor_data_collection_rule_destinations" ...)*

------
https://chatgpt.com/codex/tasks/task_b_68ad7b7912948332bd9ff74e6e8621a1