### PR TITLE
Configure insights module with required variables

### DIFF
--- a/workload/terraform/greenfield/AADDSscenario/avd.tf
+++ b/workload/terraform/greenfield/AADDSscenario/avd.tf
@@ -140,8 +140,7 @@ data "azurerm_log_analytics_workspace" "lawksp" {
     azurerm_virtual_desktop_workspace.workspace,
     azurerm_virtual_desktop_host_pool.hostpool,
     azurerm_virtual_desktop_application_group.dag,
-    azurerm_virtual_desktop_workspace_application_group_association.ws-dag,
-    module.avdi
+    azurerm_virtual_desktop_workspace_application_group_association.ws-dag
   ]
 }
 

--- a/workload/terraform/greenfield/AADDSscenario/main.tf
+++ b/workload/terraform/greenfield/AADDSscenario/main.tf
@@ -1,9 +1,25 @@
 # Creates Azure Virtual Desktop Insights Log Analytics Workspace
-module "avdi" {
-  source      = "../../modules/insights"
-  avdLocation = var.avdLocation
-  prefix      = var.prefix
-  rg_avdi     = var.rg_avdi
+module "dcr" {
+  source                                                      = "../../modules/insights"
+  name                                                        = "avddcr1"
+  monitor_data_collection_rule_resource_group_name            = azurerm_resource_group.rg.name
+  monitor_data_collection_rule_location                       = azurerm_resource_group.rg.location
+  monitor_data_collection_rule_name                           = "microsoft-avdi-${var.avdLocation}"
+  monitor_data_collection_rule_association_target_resource_id = azurerm_windows_virtual_machine.avd_vm[0].id
+  monitor_data_collection_rule_data_flow = [
+    {
+      destinations = [data.azurerm_log_analytics_workspace.lawksp.name]
+      streams      = ["Microsoft-Perf", "Microsoft-Event"]
+    }
+  ]
+  monitor_data_collection_rule_destinations = {
+    log_analytics = {
+      name                  = data.azurerm_log_analytics_workspace.lawksp.name
+      workspace_resource_id = data.azurerm_log_analytics_workspace.lawksp.id
+    }
+  }
+  resource_group_name = azurerm_resource_group.rg.name
+  target_resource_id  = azurerm_windows_virtual_machine.avd_vm[0].id
 }
 
 # Creates the Azure Virtual Desktop Spoke Network resources
@@ -47,7 +63,7 @@ module "poolremoteapp" {
   rg_shared_name = var.rg_shared_name
   prefix         = var.prefix
   rfc3339        = var.rfc3339
-  depends_on     = [module.avdi.avdLocation]
+  depends_on     = [module.dcr]
 }
 */
 
@@ -65,7 +81,7 @@ module "personal" {
   prefix         = var.prefix
   rfc3339        = var.rfc3339
   pag            = "${var.pag}-${substr(var.avdLocation,0,5)}-${var.prefix}" //var.pag
-  depends_on     = [module.avdi.avdLocation]
+  depends_on     = [module.dcr]
 }
 */
 

--- a/workload/terraform/greenfield/ADDSscenario/main.insights.tf
+++ b/workload/terraform/greenfield/ADDSscenario/main.insights.tf
@@ -5,7 +5,7 @@ module "dcr" {
   monitor_data_collection_rule_resource_group_name            = azurerm_resource_group.mon.name
   name                                                        = "avddcr1"
   monitor_data_collection_rule_kind                           = "Windows"
-  monitor_data_collection_rule_location                       = azurerm_resource_group.this.location
+  monitor_data_collection_rule_location                       = azurerm_resource_group.mon.location
   monitor_data_collection_rule_name                           = "microsoft-avdi-eastus"
   monitor_data_collection_rule_association_target_resource_id = azurerm_windows_virtual_machine.avd_vm[0].id
   monitor_data_collection_rule_data_flow = [

--- a/workload/terraform/greenfield/zerotrust/avd.tf
+++ b/workload/terraform/greenfield/zerotrust/avd.tf
@@ -140,8 +140,7 @@ data "azurerm_log_analytics_workspace" "lawksp" {
     azurerm_virtual_desktop_workspace.workspace,
     azurerm_virtual_desktop_host_pool.hostpool,
     azurerm_virtual_desktop_application_group.dag,
-    azurerm_virtual_desktop_workspace_application_group_association.ws-dag,
-    module.avdi
+    azurerm_virtual_desktop_workspace_application_group_association.ws-dag
   ]
 }
 

--- a/workload/terraform/greenfield/zerotrust/main.tf
+++ b/workload/terraform/greenfield/zerotrust/main.tf
@@ -1,9 +1,25 @@
 # Creates Azure Virtual Desktop Insights Log Analytics Workspace
-module "avdi" {
-  source      = "../../modules/insights"
-  avdLocation = var.avdLocation
-  prefix      = var.prefix
-  rg_avdi     = var.rg_avdi
+module "dcr" {
+  source                                                      = "../../modules/insights"
+  name                                                        = "avddcr1"
+  monitor_data_collection_rule_resource_group_name            = azurerm_resource_group.rg.name
+  monitor_data_collection_rule_location                       = azurerm_resource_group.rg.location
+  monitor_data_collection_rule_name                           = "microsoft-avdi-${var.avdLocation}"
+  monitor_data_collection_rule_association_target_resource_id = azurerm_windows_virtual_machine.avd_vm[0].id
+  monitor_data_collection_rule_data_flow = [
+    {
+      destinations = [data.azurerm_log_analytics_workspace.lawksp.name]
+      streams      = ["Microsoft-Perf", "Microsoft-Event"]
+    }
+  ]
+  monitor_data_collection_rule_destinations = {
+    log_analytics = {
+      name                  = data.azurerm_log_analytics_workspace.lawksp.name
+      workspace_resource_id = data.azurerm_log_analytics_workspace.lawksp.id
+    }
+  }
+  resource_group_name = azurerm_resource_group.rg.name
+  target_resource_id  = azurerm_windows_virtual_machine.avd_vm[0].id
 }
 
 # Creates the Azure Virtual Desktop Spoke Network resources
@@ -47,7 +63,7 @@ module "poolremoteapp" {
   rg_shared_name = var.rg_shared_name
   prefix         = var.prefix
   rfc3339        = var.rfc3339
-  depends_on     = [module.avdi.avdLocation]
+  depends_on     = [module.dcr]
 }
 */
 
@@ -65,6 +81,6 @@ module "personal" {
   prefix         = var.prefix
   rfc3339        = var.rfc3339
   pag            = "${var.pag}-${substr(var.avdLocation,0,5)}-${var.prefix}" //var.pag
-  depends_on     = [module.avdi.avdLocation]
+  depends_on     = [module.dcr]
 }
 */


### PR DESCRIPTION
## Summary
- populate mandatory monitor_data_collection_rule settings when using the insights module in AADDS and Zero Trust scenarios
- correct data collection rule location for ADDS scenario

## Testing
- `terraform plan` *(fails: Invalid combination of arguments; unsupported argument)*

------
https://chatgpt.com/codex/tasks/task_b_68ad7b7a9b2083328b17f541aab10579