### PR TITLE
feat: make OU path optional for domain join

### DIFF
--- a/workload/terraform/greenfield/AADDSscenario/terraform.tfvars.sample
+++ b/workload/terraform/greenfield/AADDSscenario/terraform.tfvars.sample
@@ -41,6 +41,7 @@ ws_log_categories        = ["Checkpoint", "Management", "Error", "Feed"]
 
 prefix                = "test"
 local_admin_username  = "localadmin" # Your AVD VM login id to manage username
+ou_path               = "OU=AVD,OU=AADDS,DC=contoso,DC=net" # optional
 vm_size               = "Standard_D8s_v5"
 vnet_range            = ["10.10.1.0/24"] #replace with your IP addresses
 subnet_range          = ["10.10.1.0/26"] #replace with your IP addresses

--- a/workload/terraform/greenfield/AADDSscenario/variables.tf
+++ b/workload/terraform/greenfield/AADDSscenario/variables.tf
@@ -145,6 +145,12 @@ variable "local_admin_username" {
   description = "local admin username"
 }
 
+variable "ou_path" {
+  type        = string
+  description = "Distinguished name of the organizational unit for the session host"
+  default     = null
+}
+
 variable "image_name" {
   type        = string
   description = "Name of the custome image to use"

--- a/workload/terraform/greenfield/ADDSscenario/variables.tf
+++ b/workload/terraform/greenfield/ADDSscenario/variables.tf
@@ -119,7 +119,9 @@ variable "offer" {
 }
 
 variable "ou_path" {
+  type        = string
   description = "Distinguished name of the organizational unit for the session host"
+  default     = null
 }
 
 variable "pag" {


### PR DESCRIPTION
## Summary
- allow specifying an optional organizational unit path when joining machines to the domain
- document the optional `ou_path` setting in AADDS sample variables

## Testing
- `terraform plan -var-file=terraform.tfvars.sample -refresh=false` (AADDSscenario) *(fails: missing required module arguments)*
- `terraform plan -var-file=terraform.tfvars.sample -refresh=false` (ADDSscenario) *(fails: Azure CLI not found for provider authentication)*

------
https://chatgpt.com/codex/tasks/task_b_68ad7b7901388332b7a1ac1e67958224