### PR TITLE
fix(AADDS): add optional variables for AVD pool modules

### DIFF
--- a/workload/terraform/greenfield/AADDSscenario/CHANGELOG.md
+++ b/workload/terraform/greenfield/AADDSscenario/CHANGELOG.md
@@ -8,4 +8,5 @@
 - Added domain join user creation and associated variables to enable automated AADDS joins.
 - Added `source_image_id` for session host VMs and cleaned unused resources for clarity.
 - Fixed missing variable declarations and corrected resource references to prevent runtime errors.
+- Declared optional variables for remote app and personal host pool modules to avoid unexpected attribute errors.
 - Added comprehensive documentation in `README.md` for easier deployment and maintenance.

--- a/workload/terraform/greenfield/AADDSscenario/variables.tf
+++ b/workload/terraform/greenfield/AADDSscenario/variables.tf
@@ -12,6 +12,12 @@ variable "rg_stor" {
   description = "Name of the Resource group in which to deploy storage"
 }
 
+variable "rg_fslogix" {
+  type        = string
+  description = "Name of the Resource group in which to deploy FSLogix storage resources"
+  default     = null
+}
+
 variable "rg_network" {
   type        = string
   description = "Name of the Resource group in which to deploy network resources"
@@ -102,6 +108,42 @@ variable "workspace" {
 variable "hostpool" {
   type        = string
   description = "Name of the Azure Virtual Desktop host pool"
+}
+
+variable "ragworkspace" {
+  type        = string
+  description = "Name of the Azure Virtual Desktop Remote Apps workspace"
+  default     = null
+}
+
+variable "raghostpool" {
+  type        = string
+  description = "Name of the Azure Virtual Desktop Remote Apps host pool"
+  default     = null
+}
+
+variable "rag" {
+  type        = string
+  description = "Name of the Azure Virtual Desktop Remote App group"
+  default     = null
+}
+
+variable "pworkspace" {
+  type        = string
+  description = "Name of the Azure Virtual Desktop personal workspace"
+  default     = null
+}
+
+variable "personalpool" {
+  type        = string
+  description = "Name of the Azure Virtual Desktop personal host pool"
+  default     = null
+}
+
+variable "pag" {
+  type        = string
+  description = "Name of the Azure Virtual Desktop personal application group"
+  default     = null
 }
 
 variable "dns_servers" {


### PR DESCRIPTION
## Summary
- declare optional variables for remote app and personal host pool modules
- document change in changelog

## Testing
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_b_68adc5dbf9b88332b8748571db7f1362