### PR TITLE
Fix Terraform role assignments and workspace lookups

### DIFF
--- a/workload/terraform/greenfield/AADDSscenario/afstorage.tf
+++ b/workload/terraform/greenfield/AADDSscenario/afstorage.tf
@@ -42,7 +42,7 @@ data "azurerm_role_definition" "storage_role" {
 resource "azurerm_role_assignment" "af_role" {
   scope              = azurerm_storage_account.storage.id
   role_definition_id = data.azurerm_role_definition.storage_role.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }
 
 # Get Private DNS Zone for the Storage Private Endpoints

--- a/workload/terraform/greenfield/AADDSscenario/insights.tf
+++ b/workload/terraform/greenfield/AADDSscenario/insights.tf
@@ -1,5 +1,5 @@
 resource "azurerm_log_analytics_workspace" "law" {
-  name                = lower(replace("law-avd-${var.prefix}", "-", ""))
+  name                = lower(replace("log-avd-${var.prefix}", "-", ""))
   location            = azurerm_resource_group.rg_avdi.location
   resource_group_name = azurerm_resource_group.rg_avdi.name
   sku                 = "PerGB2018"

--- a/workload/terraform/greenfield/AADDSscenario/keyvault.tf
+++ b/workload/terraform/greenfield/AADDSscenario/keyvault.tf
@@ -80,6 +80,10 @@ resource "azurerm_key_vault_secret" "localpassword" {
   key_vault_id = azurerm_key_vault.kv.id
   content_type = "Password"
 
+  depends_on = [
+    azurerm_key_vault_access_policy.deploy
+  ]
+
   lifecycle { ignore_changes = [tags] }
 }
 

--- a/workload/terraform/greenfield/AADDSscenario/rbac.tf
+++ b/workload/terraform/greenfield/AADDSscenario/rbac.tf
@@ -10,7 +10,7 @@ data "azuread_group" "adds_group" {
 resource "azurerm_role_assignment" "role" {
   scope              = azurerm_virtual_desktop_application_group.dag.id
   role_definition_id = data.azurerm_role_definition.role.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }
 
 # Grant users access to Microsoft Entra ID-joined virtual machines
@@ -22,5 +22,5 @@ data "azurerm_role_definition" "vm_useraad" {
 resource "azurerm_role_assignment" "vm_useraad" {
   scope              = azurerm_resource_group.shrg.id
   role_definition_id = data.azurerm_role_definition.vm_useraad.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }

--- a/workload/terraform/greenfield/AADscenario/afstorage.tf
+++ b/workload/terraform/greenfield/AADscenario/afstorage.tf
@@ -8,19 +8,19 @@ resource "azurerm_user_assigned_identity" "mi" {
 ## https://docs.microsoft.com/azure/storage/common/storage-account-overview
 ## Create a File Storage Account 
 resource "azurerm_storage_account" "storage" {
-  name                      = local.storage_name
-  resource_group_name       = azurerm_resource_group.rg.name
-  location                  = azurerm_resource_group.rg.location
-  min_tls_version           = "TLS1_2"
-  account_tier              = "Premium"
-  account_replication_type  = "LRS"
-  account_kind              = "FileStorage"
-  tags                      = local.tags
+  name                     = local.storage_name
+  resource_group_name      = azurerm_resource_group.rg.name
+  location                 = azurerm_resource_group.rg.location
+  min_tls_version          = "TLS1_2"
+  account_tier             = "Premium"
+  account_replication_type = "LRS"
+  account_kind             = "FileStorage"
+  tags                     = local.tags
   identity {
     type = "SystemAssigned"
   }
   azure_files_authentication {
-    directory_type = "AADKERB"  
+    directory_type = "AADKERB"
   }
   lifecycle {
     ignore_changes = [
@@ -50,7 +50,7 @@ data "azurerm_role_definition" "storage_role" {
 resource "azurerm_role_assignment" "af_role" {
   scope              = azurerm_storage_account.storage.id
   role_definition_id = data.azurerm_role_definition.storage_role.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }
 
 # Get Private DNS Zone for the Storage Private Endpoints

--- a/workload/terraform/greenfield/AADscenario/avd.tf
+++ b/workload/terraform/greenfield/AADscenario/avd.tf
@@ -102,15 +102,15 @@ resource "azurerm_virtual_desktop_workspace_application_group_association" "ws-d
 
 # Get Log Analytics Workspace data
 data "azurerm_log_analytics_workspace" "lawksp" {
-  name                = lower(replace("law-avd-${substr(var.avdLocation, 0, 5)}", "-", ""))
-  resource_group_name = "rg-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}-${var.rg_avdi}"
+  name                = lower(replace("log-avd-${var.environment}-${var.avdLocation}", "-", ""))
+  resource_group_name = azurerm_resource_group.mon.name
 
   depends_on = [
     azurerm_virtual_desktop_workspace.workspace,
     azurerm_virtual_desktop_host_pool.hostpool,
     azurerm_virtual_desktop_application_group.dag,
     azurerm_virtual_desktop_workspace_application_group_association.ws-dag,
-    module.avdi
+    module.avm_res_operationalinsights_workspace
   ]
 }
 

--- a/workload/terraform/greenfield/AADscenario/rbac.tf
+++ b/workload/terraform/greenfield/AADscenario/rbac.tf
@@ -10,7 +10,7 @@ data "azuread_group" "adds_group" {
 resource "azurerm_role_assignment" "role" {
   scope              = module.avm_res_desktopvirtualization_hostpool.resource.id
   role_definition_id = data.azurerm_role_definition.role.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }
 
 # Grant users access to Microsoft Entra ID-joined virtual machines
@@ -22,5 +22,5 @@ data "azurerm_role_definition" "vm_useraad" {
 resource "azurerm_role_assignment" "vm_useraad" {
   scope              = azurerm_resource_group.shrg.id
   role_definition_id = data.azurerm_role_definition.vm_useraad.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }

--- a/workload/terraform/greenfield/zerotrust/afstorage.tf
+++ b/workload/terraform/greenfield/zerotrust/afstorage.tf
@@ -77,7 +77,7 @@ data "azurerm_role_definition" "storage_role" {
 resource "azurerm_role_assignment" "af_role" {
   scope              = azurerm_storage_account.storage.id
   role_definition_id = data.azurerm_role_definition.storage_role.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 
   depends_on = [azurerm_storage_account.storage]
 }

--- a/workload/terraform/greenfield/zerotrust/avd.tf
+++ b/workload/terraform/greenfield/zerotrust/avd.tf
@@ -132,16 +132,14 @@ resource "azurerm_virtual_desktop_workspace_application_group_association" "ws-d
 
 # Get Log Analytics Workspace data
 data "azurerm_log_analytics_workspace" "lawksp" {
-  name                = lower(replace("law-avd-${substr(var.avdLocation, 0, 5)}", "-", ""))
+  name                = lower(replace("log-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}", "-", ""))
   resource_group_name = "rg-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}-${var.rg_avdi}"
 
   depends_on = [
-    data.azurerm_log_analytics_workspace.lawksp,
     azurerm_virtual_desktop_workspace.workspace,
     azurerm_virtual_desktop_host_pool.hostpool,
     azurerm_virtual_desktop_application_group.dag,
-    azurerm_virtual_desktop_workspace_application_group_association.ws-dag,
-    module.avdi
+    azurerm_virtual_desktop_workspace_application_group_association.ws-dag
   ]
 }
 

--- a/workload/terraform/greenfield/zerotrust/rbac.tf
+++ b/workload/terraform/greenfield/zerotrust/rbac.tf
@@ -10,7 +10,7 @@ data "azuread_group" "adds_group" {
 resource "azurerm_role_assignment" "role" {
   scope              = azurerm_virtual_desktop_application_group.dag.id
   role_definition_id = data.azurerm_role_definition.role.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }
 
 # Grant users access to Microsoft Entra ID-joined VMs
@@ -22,5 +22,5 @@ data "azurerm_role_definition" "vm_useraad" {
 resource "azurerm_role_assignment" "vm_useraad" {
   scope              = azurerm_resource_group.shrg.id
   role_definition_id = data.azurerm_role_definition.vm_useraad.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }

--- a/workload/terraform/modules/alerts/lawalert.tf
+++ b/workload/terraform/modules/alerts/lawalert.tf
@@ -1,25 +1,23 @@
 module "avdi" {
-  source                                      = "../insights"
-  resource_group_name                         = var.resource_group_name
-  name                                        = var.name
-  monitor_data_collection_rule_data_flow      = var.monitor_data_collection_rule_data_flow
-  monitor_data_collection_rule_name           = var.monitor_data_collection_rule_name
-  monitor_data_collection_rule_resource_group_name = var.monitor_data_collection_rule_resource_group_name
-  monitor_data_collection_rule_location       = var.monitor_data_collection_rule_location
-  target_resource_id                          = var.target_resource_id
+  source                                                      = "../insights"
+  resource_group_name                                         = var.resource_group_name
+  name                                                        = var.name
+  monitor_data_collection_rule_data_flow                      = var.monitor_data_collection_rule_data_flow
+  monitor_data_collection_rule_name                           = var.monitor_data_collection_rule_name
+  monitor_data_collection_rule_resource_group_name            = var.monitor_data_collection_rule_resource_group_name
+  monitor_data_collection_rule_location                       = var.monitor_data_collection_rule_location
+  target_resource_id                                          = var.target_resource_id
   monitor_data_collection_rule_association_target_resource_id = var.monitor_data_collection_rule_association_target_resource_id
-  monitor_data_collection_rule_destinations   = var.monitor_data_collection_rule_destinations
+  monitor_data_collection_rule_destinations                   = var.monitor_data_collection_rule_destinations
 }
 
 data "azurerm_log_analytics_workspace" "lawksp" {
-  name                = lower(replace("law-avd-${substr(var.avdLocation, 0, 5)}", "-", ""))
+  name                = lower(replace("log-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}", "-", ""))
   resource_group_name = "rg-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}-${var.rg_avdi}"
 
   depends_on = [
-    data.azurerm_log_analytics_workspace.lawksp,
     module.avdi
   ]
-
 }
 
 //  target_resource_type     = "microsoft.desktopvirtualization/hostpools"

--- a/workload/terraform/modules/avd/personal/personalpool.tf
+++ b/workload/terraform/modules/avd/personal/personalpool.tf
@@ -82,14 +82,14 @@ resource "azurerm_virtual_desktop_workspace_application_group_association" "ws-d
 
 # Get Log Analytics Workspace data
 data "azurerm_log_analytics_workspace" "lawksp" {
-  name                = lower(replace("law-avd-${var.prefix}", "-", ""))
+  name                = lower(replace("log-avd-${var.prefix}", "-", ""))
   resource_group_name = "rg-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}-${var.rg_avdi}"
 
   depends_on = [
     azurerm_virtual_desktop_workspace.pworkspace,
     azurerm_virtual_desktop_host_pool.personalpool,
     azurerm_virtual_desktop_application_group.pag,
-    azurerm_virtual_desktop_workspace_application_group_association.ws-dag,
+    azurerm_virtual_desktop_workspace_application_group_association.ws-dag
   ]
 }
 

--- a/workload/terraform/modules/avd/poolremoteapp/remoteapp.tf
+++ b/workload/terraform/modules/avd/poolremoteapp/remoteapp.tf
@@ -47,15 +47,14 @@ resource "azurerm_virtual_desktop_workspace_application_group_association" "ws-r
 
 # Get Log Analytics Workspace data
 data "azurerm_log_analytics_workspace" "lawksp" {
-  name                = lower(replace("law-avd-${var.prefix}", "-", ""))
+  name                = lower(replace("log-avd-${var.prefix}", "-", ""))
   resource_group_name = azurerm_resource_group.sh.name
 
   depends_on = [
     azurerm_virtual_desktop_workspace.ragworkspace,
     azurerm_virtual_desktop_host_pool.raghostpool,
     azurerm_virtual_desktop_application_group.raag,
-    azurerm_virtual_desktop_workspace_application_group_association.ws-raag,
-    data.azurerm_log_analytics_workspace.lawksp
+    azurerm_virtual_desktop_workspace_application_group_association.ws-raag
   ]
 }
 
@@ -72,37 +71,37 @@ resource "azurerm_monitor_diagnostic_setting" "avd-hpr" {
   ]
   log_analytics_destination_type = "Dedicated"
 
-  enabled_log  {
+  enabled_log {
     category = "AgentHealthStatus"
 
-      }
+  }
   enabled_log {
     category = "Checkpoint"
-    
+
   }
   enabled_log {
     category = "Connection"
-    
+
   }
   enabled_log {
     category = "Error"
-    
+
   }
   enabled_log {
     category = "HostRegistration"
-    
+
   }
   enabled_log {
     category = "Management"
-    
+
   }
   enabled_log {
     category = "NetworkData"
-    
+
   }
   enabled_log {
     category = "SessionHostManagement"
-    
+
   }
 }
 
@@ -121,20 +120,20 @@ resource "azurerm_monitor_diagnostic_setting" "avd-rag1" {
 
   enabled_log {
     category = "Checkpoint"
-    
+
 
 
   }
 
   enabled_log {
     category = "Error"
-    
+
 
 
   }
   enabled_log {
     category = "Management"
-    
+
 
 
   }
@@ -152,27 +151,27 @@ resource "azurerm_monitor_diagnostic_setting" "avd-wksp2" {
 
   enabled_log {
     category = "Checkpoint"
-    
+
 
 
   }
 
   enabled_log {
     category = "Error"
-    
+
 
 
   }
   enabled_log {
     category = "Management"
-    
+
 
 
   }
 
   enabled_log {
     category = "Feed"
-    
+
 
 
   }

--- a/workload/terraform/modules/azurefiles/afstorage.tf
+++ b/workload/terraform/modules/azurefiles/afstorage.tf
@@ -48,7 +48,7 @@ data "azurerm_role_definition" "storage_role" {
 resource "azurerm_role_assignment" "af_role" {
   scope              = azurerm_storage_account.storage.id
   role_definition_id = data.azurerm_role_definition.storage_role.id
-  principal_id       = data.azuread_group.adds_group.id
+  principal_id       = data.azuread_group.adds_group.object_id
 }
 
 # Get Private DNS Zone for the Storage Private Endpoints

--- a/workload/terraform/modules/network/main.tf
+++ b/workload/terraform/modules/network/main.tf
@@ -10,21 +10,21 @@ resource "azurerm_virtual_network" "vnet" {
 }
 
 resource "azurerm_subnet" "subnet" {
-  name                                      = "${var.snet}-${substr(var.avdLocation, 0, 5)}-${var.prefix}-001"
-  resource_group_name                       = "rg-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}-${var.rg_network}"
-  virtual_network_name                      = azurerm_virtual_network.vnet.name
-  address_prefixes                          = var.subnet_range
-  depends_on                                = [azurerm_resource_group.net]
+  name                 = "${var.snet}-${substr(var.avdLocation, 0, 5)}-${var.prefix}-001"
+  resource_group_name  = "rg-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}-${var.rg_network}"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = var.subnet_range
+  depends_on           = [azurerm_resource_group.net]
 }
 
 resource "azurerm_subnet" "pesubnet" {
-  name                                      = "${var.pesnet}-${substr(var.avdLocation, 0, 5)}-${var.prefix}-001"
-  resource_group_name                       = "rg-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}-${var.rg_network}"
-  virtual_network_name                      = azurerm_virtual_network.vnet.name
-  address_prefixes                          = var.pesubnet_range
+  name                 = "${var.pesnet}-${substr(var.avdLocation, 0, 5)}-${var.prefix}-001"
+  resource_group_name  = "rg-avd-${substr(var.avdLocation, 0, 5)}-${var.prefix}-${var.rg_network}"
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = var.pesubnet_range
   # private_endpoint_network_policies = "Enabled"
   service_endpoints = ["Microsoft.Storage", "Microsoft.KeyVault"]
-  depends_on                                = [azurerm_resource_group.net]
+  depends_on        = [azurerm_resource_group.net, azurerm_subnet.subnet]
 }
 
 resource "azurerm_subnet_network_security_group_association" "nsg_assoc" {
@@ -85,7 +85,7 @@ resource "azurerm_virtual_network_peering" "peer2" {
 }
 
 resource "azurerm_virtual_network_peering" "peer3" {
-    count = local.use_same_hub_identity_vnet ? 0 : 1
+  count = local.use_same_hub_identity_vnet ? 0 : 1
 
   name                         = "peer_${var.prefix}_identity_avdspoke"
   resource_group_name          = var.identity_rg


### PR DESCRIPTION
## Summary
- use Azure AD object IDs for role assignments
- align Log Analytics workspace lookup naming and dependencies
- wait for Key Vault access policy before creating secret
- serialize private endpoint subnet creation

## Testing
- `terraform fmt -check workload/terraform/greenfield/AADscenario/rbac.tf workload/terraform/greenfield/AADscenario/afstorage.tf workload/terraform/greenfield/AADscenario/avd.tf workload/terraform/greenfield/AADDSscenario/rbac.tf workload/terraform/greenfield/AADDSscenario/afstorage.tf workload/terraform/greenfield/AADDSscenario/keyvault.tf workload/terraform/greenfield/AADDSscenario/insights.tf workload/terraform/greenfield/zerotrust/rbac.tf workload/terraform/greenfield/zerotrust/afstorage.tf workload/terraform/greenfield/zerotrust/avd.tf workload/terraform/modules/network/main.tf workload/terraform/modules/azurefiles/afstorage.tf workload/terraform/modules/avd/personal/personalpool.tf workload/terraform/modules/avd/poolremoteapp/remoteapp.tf workload/terraform/modules/alerts/lawalert.tf`
- `terraform -chdir=workload/terraform/greenfield/AADscenario init -backend=false`
- `terraform -chdir=workload/terraform/greenfield/AADscenario validate`


------
https://chatgpt.com/codex/tasks/task_b_68aebfa52d0c8332b2ed6be583b3b3b0